### PR TITLE
Subjectの処理を実装しました

### DIFF
--- a/backend/laravel/app/Http/Controllers/UsersController.php
+++ b/backend/laravel/app/Http/Controllers/UsersController.php
@@ -2,9 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Subject;
 use Illuminate\Http\Request;
-
-use App\User;
 
 use Carbon\Carbon;
 
@@ -18,7 +17,8 @@ class UsersController extends Controller
 
         // 本日実施したプランを取得
         $plans = $user->plans()->where('date', $today)->get();
-        return view('plan.today', compact('user', 'today', 'plans'));
+        $subjects = Subject::orderBy('id')->get();
+        return view('plan.today', compact('user', 'today', 'plans', 'subjects'));
     }
 
     public function addplan(Request $request)
@@ -28,9 +28,9 @@ class UsersController extends Controller
         ]);
         $user = \Auth::user();
         $date = Carbon::today();
-        $subject = $request->subject;
+        $subject_id = $request->subject_id;
         $content = $request->content;
-        $user->plans()->create(compact('date', 'subject', 'content'));
+        $user->plans()->create(compact('date', 'subject_id', 'content'));
 
         return redirect()->route('plan.today');
     }

--- a/backend/laravel/app/Plan.php
+++ b/backend/laravel/app/Plan.php
@@ -3,12 +3,13 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Plan extends Model
 {
     protected $fillable = [
-        'subject',
         'date',
+        'subject_id',
         'started_at',
         'ended_at',
         'content',
@@ -21,10 +22,14 @@ class Plan extends Model
         'started_at',
         'ended_at',
     ];
-
     
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function subject(): BelongsTo
+    {
+        return $this->belongsTo(Subject::class);
     }
 }

--- a/backend/laravel/app/Subject.php
+++ b/backend/laravel/app/Subject.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Subject extends Model
+{
+    protected $fillable = [
+        'label',
+        'name',
+    ];
+    
+    public function plans(): HasMany
+    {
+        return $this->hasMany(Plan::class);
+    }
+
+    public function getBgColorAttribute(): string
+    {
+        return [
+            'Japanese' => 'bg-red-600',
+            'English' => 'bg-pink-600',
+            'Math' => 'bg-blue-700',
+            'Biology' => 'bg-green-400',
+            'Chemistry' => 'bg-green-400',
+            'Physics' => 'bg-green-400',
+            'Japanese-history' => 'bg-green-400',
+            'World-history' => 'bg-yellow-300',
+            'Geography' => 'bg-yellow-300',
+            'Politics-and-economy' => 'bg-yellow-300',
+            'Ethics' => 'bg-yellow-300',
+        ][$this->label] ?? 'bg-gray-400';
+    }
+}

--- a/backend/laravel/database/migrations/2021_03_09_213657_create_subjects_table.php
+++ b/backend/laravel/database/migrations/2021_03_09_213657_create_subjects_table.php
@@ -15,18 +15,8 @@ class CreateSubjectsTable extends Migration
     {
         Schema::create('subjects', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('Japanese');
-            $table->string('English');
-            $table->string('Math');
-            $table->string('Biology');
-            $table->string('Chemistry');
-            $table->string('Physics');
-            $table->string('Japanese-history');
-            $table->string('World-history');
-            $table->string('Geography');
-            $table->string('Politics-and-economy');
-            $table->string('Ethics');
-            $table->string('others');
+            $table->string('label');
+            $table->string('name');
             $table->timestamps();
         });
     }

--- a/backend/laravel/database/migrations/2021_03_16_163545_add_column_subject_id_to_plans_table.php
+++ b/backend/laravel/database/migrations/2021_03_16_163545_add_column_subject_id_to_plans_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnSubjectIdToPlansTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->unsignedBigInteger('subject_id')->nullable()->after('user_id');
+            $table->foreign('subject_id')->references('id')->on('subjects')->onDelete('cascade');
+            $table->dropColumn('subject');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropForeign(['subject_id']);
+            $table->dropColumn('subject_id');
+            $table->string('subject');
+        });
+    }
+}

--- a/backend/laravel/database/seeds/DatabaseSeeder.php
+++ b/backend/laravel/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(SubjectsTableSeeder::class);
     }
 }

--- a/backend/laravel/database/seeds/SubjectsTableSeeder.php
+++ b/backend/laravel/database/seeds/SubjectsTableSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Subject;
+use Illuminate\Database\Seeder;
+
+class SubjectsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Subject::insert([
+            ['label' => 'Japanese', 'name' => '国語', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'English', 'name' => '英語', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Math', 'name' => '数学', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Biology', 'name' => '生物学', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Chemistry', 'name' => '化学', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Physics', 'name' => '物理学', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Japanese-history', 'name' => '日本史', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'World-history', 'name' => '世界史', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Geography', 'name' => '地理', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Politics-and-economy', 'name' => '政治・経済', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Ethics', 'name' => '倫理', 'created_at' => now(), 'updated_at' => now()],
+            ['label' => 'Others', 'name' => 'その他', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+        
+    }
+}

--- a/backend/laravel/resources/views/parts/_subject_label.blade.php
+++ b/backend/laravel/resources/views/parts/_subject_label.blade.php
@@ -1,0 +1,12 @@
+<label
+    class="{{ $subject->bgColor }} text-xs border-2 border-transparent ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75"
+>
+    <input
+        id="{{ $subject->label }}"
+        type="checkbox"
+        name="subject_id"
+        value="{{ $subject->id }}"
+        class="w-0"
+    >
+    {{ $subject->name }}
+</label>

--- a/backend/laravel/resources/views/plan/today.blade.php
+++ b/backend/laravel/resources/views/plan/today.blade.php
@@ -16,8 +16,8 @@
             <tr>
                 <td>
                     <p class="text-white">
-                        <span class="text-xs border-2 border-transparent bg-black py-1 px-2 font-bold text-white rounded transition-all mr-2">
-                            {{ $plan->subject }}
+                        <span class="{{ $plan->subject->bgColor ?? '' }} text-xs border-2 border-transparent bg-black py-1 px-2 font-bold text-white rounded transition-all mr-2">
+                            {{ $plan->subject->name ?? '' }}
                         </span>
                         {{ $plan->content }}
                     </p>
@@ -39,54 +39,7 @@
                 <div class="text-gray-700 text-sm mb-2">
                     科目
                 </div>
-                <label class="text-xs border-2 border-transparent bg-red-600 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Japanese" type="checkbox" value="国語" class="w-0">
-                    国語
-                </label>
-                <label class="text-xs border-2 border-transparent bg-pink-600 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="English" type="checkbox" value="英語" class="w-0 opacity-0">
-                    英語
-                </label>
-                <label class="text-xs border-2 border-transparent bg-blue-700 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Math" type="checkbox" value="数学" class="w-0 opacity-0">
-                    数学
-                </label>
-                <label class="text-xs border-2 border-transparent bg-green-400 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Biology" type="checkbox" value="生物" class="w-0 opacity-0">
-                    生物
-                </label>
-                <label class="text-xs border-2 border-transparent bg-green-400 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Chemistry" type="checkbox" value="化学" class="w-0 opacity-0">
-                    化学
-                </label>
-                <label class="text-xs border-2 border-transparent bg-green-400 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Physics" type="checkbox" value="物理" class="w-0 opacity-0">
-                    物理
-                </label>
-                <label class="text-xs border-2 border-transparent bg-yellow-300 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Japanese-history" type="checkbox" value="日本史" class="w-0 opacity-0">
-                    日本史
-                </label>
-                <label class="text-xs border-2 border-transparent bg-yellow-300 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="World-history" type="checkbox" value="世界史" class="w-0 opacity-0">
-                    世界史
-                </label>
-                <label class="text-xs border-2 border-transparent bg-yellow-300 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Geography" type="checkbox" value="地理" class="w-0 opacity-0">
-                    地理
-                </label>
-                <label class="text-xs border-2 border-transparent bg-yellow-300 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Politics-and-economy" type="checkbox" value="政治・経済" class="w-0 opacity-0">
-                    政治・経済
-                </label>
-                <label class="text-xs border-2 border-transparent bg-yellow-300 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="Ethics" type="checkbox" value="倫理" class="w-0 opacity-0">
-                    倫理
-                </label>
-                <label class="text-xs border-2 border-transparent bg-gray-400 ml-0 mb-1 py-1 px-2 font-bold uppercase text-white rounded transition-all cursor-pointer hover:opacity-75">
-                    <input name="subject" id="others" type="checkbox" value="その他" class="w-0 opacity-0">
-                    その他
-                </label>
+                @each('parts._subject_label', $subjects, 'subject')
                 @error('subject')
                 <div class="mt-2 alert alert-danger">{{ $message }}</div>
                 @enderror


### PR DESCRIPTION
### 実装内容
1. subjectsテーブルの構造を変更しました。migrationファイルをご確認ください。
2. plansテーブルのsubjectカラムを削除し、subject_idを追加。subjectsテーブルのidとリレーションを貼っています。
3. Subjectモデルを作成しています。
4. SubjectsTableSeederでデフォルトデータを挿入します。

以下を実行することでデータがインポートされます。
```
php artisan db:seed --class=SubjectsTableSeeder
```

5. 構造の変更に伴って実装を修正しています。

### 注意点
plansテーブルの構造も変わっているので、うまくいかない場合は一度データを消してから試してみてください。